### PR TITLE
Update import type annotation in remix.config.js

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -1,5 +1,5 @@
 import { flatRoutes } from 'remix-flat-routes'
-/** @type {import('@remix-run/dev/dist/vite/plugin').RemixVitePluginOptions} */
+/** @type {import('@remix-run/dev/dist/vite/plugin').VitePluginConfig} */
 export default {
   ignoredRouteFiles: ['**/*'],
   serverModuleFormat: 'esm',


### PR DESCRIPTION
https://github.com/remix-run/remix/commit/c358f415fa4dbfc4684cafe300edd78f09892c4c

In v2.6.0, the `RemixVitePluginOptions` type name has been renamed to `VitePluginConfig`.


_Thank you for all your work! 🙏_